### PR TITLE
Modified RoomSend to send a JSON object without type, rather than an …

### DIFF
--- a/plugin/aces.json
+++ b/plugin/aces.json
@@ -79,7 +79,6 @@
         "id": "room-send",
         "scriptName": "RoomSend",
         "params": [
-          { "id": "type", "type": "string" },
           { "id": "message", "type": "string" }
         ]
       },

--- a/plugin/c2runtime/runtime.js
+++ b/plugin/c2runtime/runtime.js
@@ -255,14 +255,14 @@ cr.plugins_.Colyseus = function(runtime)
      //  });
    };
 
-   Acts.prototype.RoomSend = function (type, data)
+   Acts.prototype.RoomSend = function (data)
    {
      if (
        this.room &&
        this.room.connection &&
        this.room.connection.readyState === WebSocket.OPEN
      ) {
-       this.room.send([type, JSON.parse(data)]);
+       this.room.send(JSON.parse(data));
 
      } else {
        console.log("RoomSend: not connected.");

--- a/plugin/c3runtime/actions.js
+++ b/plugin/c3runtime/actions.js
@@ -111,14 +111,14 @@
       // });
     },
 
-    RoomSend (type, data)
+    RoomSend (data)
     {
       if (
         this.room &&
         this.room.connection &&
         this.room.connection.readyState === WebSocket.OPEN
       ) {
-        this.room.send([type, JSON.parse(data)]);
+        this.room.send(JSON.parse(data));
 
       } else {
         console.log("RoomSend: not connected.");

--- a/plugin/lang/en-US.json
+++ b/plugin/lang/en-US.json
@@ -186,7 +186,7 @@
 
           "room-send": {
             "list-name": "Send message",
-            "display-text": "Send {0} with {1}",
+            "display-text": "Send a message with {0}",
             "description": "Send message to a room",
             "params": {
               "type": {


### PR DESCRIPTION
…array. This was causing two messages to show up on the server, rather than one. Type was removed and can now just be included in the Message JSON if desired.