### PR TITLE
fix RoomSendJSON

### DIFF
--- a/plugin/c3runtime/actions.js
+++ b/plugin/c3runtime/actions.js
@@ -52,7 +52,7 @@
 
     RoomSendJSON (type, message)
     {
-      this.RoomSend(type, JSON.parse(message));
+      C3.Plugins.Colyseus_SDK.Acts.RoomSend.call(this, type, JSON.parse(message));
     },
 
     RoomLeave()


### PR DESCRIPTION
With the current version, trying to call Send JSON Message action will result in the following error
```
Uncaught (in promise) TypeError: this.RoomSend is not a function
    at ColyseusInstance.RoomSendJSON (3b76d90e-53bb-40a9-9c31-11f0e34ce5c6:56:12)
    at Action._RunObject_AllParamsVary (action.js:26:152)
    at EventBlock._RunActions_Fast (eventBlock.js:26:208)
    at EventBlock._RunAndBlock (eventBlock.js:24:415)
    at EventBlock.Run (eventBlock.js:21:393)
    at EventBlock._RunSubEvents_Fast (eventBlock.js:30:504)
    at EventBlock._RunSubEvents (eventBlock.js:29:259)
    at EventBlock._RunAndBlock (eventBlock.js:24:441)
    at EventBlock.Run (eventBlock.js:21:393)
    at EventSheet._ExecuteTrigger (eventSheet.js:19:154)
```

Looking briefly at the code, it seems like this is caused by one of those 'this' quirks of javascript. I'm not too familiar with C3 addon development, but i tried to fix it and i think this fix should work.